### PR TITLE
Upgrade dependency versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin.publishingSettings
 
 val appName = "interest-restriction-return"
 
-resolvers += "emueller-bintray" at "http://dl.bintray.com/emueller/maven"
+resolvers += "emueller-bintray" at "https://dl.bintray.com/emueller/maven"
 
 scalacOptions += "-Ypartial-unification"
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -64,7 +64,7 @@ play.modules.enabled += "config.DIModule"
 # ~~~~~
 # The secret key is used to secure cryptographics functions.
 # If you deploy your application to several instances be sure to use the same key!
-play.crypto.secret = "OZgF7ykybYlo2lyfj11A5IWLACBsr5Ar5n0Ts4JUdN4GPUdUPgBQb4u1zjy2ItcE"
+play.http.secret.key = "OZgF7ykybYlo2lyfj11A5IWLACBsr5Ar5n0Ts4JUdN4GPUdUPgBQb4u1zjy2ItcE"
 
 # Session configuration
 # ~~~~~
@@ -87,18 +87,6 @@ play.i18n.langs = ["en"]
 # !!!WARNING!!! DO NOT CHANGE THIS ROUTER
 play.http.router = prod.Routes
 
-# Logger
-# ~~~~~
-# You can also configure logback (http://logback.qos.ch/), by providing a logger.xml file in the conf directory .
-
-# Root logger:
-logger.root = ERROR
-
-# Logger used by the framework:
-logger.play = INFO
-
-# Logger provided to your application:
-logger.application = DEBUG
 
 # Api related config
 api {
@@ -110,7 +98,7 @@ api {
   gateway.context = "organisations/interest-restriction"
 }
 
-httpHeadersWhitelist = [ "Accept", "Gov-Test-Scenario", "Content-Type", "Location", "X-Request-Timestamp", "X-Session-Id" ]
+bootstrap.http.headersAllowlist = [ "Accept", "Gov-Test-Scenario", "Content-Type", "Location", "X-Request-Timestamp", "X-Session-Id" ]
 internalServiceHostPatterns = [ "localhost" ]
 
 # API Definitions endpoints enabled flag

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,14 +6,14 @@ import sbt._
 object AppDependencies {
 
   val compile = Seq(
-    "uk.gov.hmrc"             %% "bootstrap-play-26"            % "1.3.0",
+    "uk.gov.hmrc"             %% "bootstrap-play-26"            % "2.1.0",
     "org.typelevel"           %% "cats-core"                    % "2.0.0",
-    "uk.gov.hmrc"             %% "play-hmrc-api"                % "3.6.0-play-26",
+    "uk.gov.hmrc"             %% "play-hmrc-api"                % "4.1.0-play-26",
     "com.chuusai"             %% "shapeless"                    % "2.3.3"
   )
 
   val test = Seq(
-    "uk.gov.hmrc"             %% "bootstrap-play-26"            % "1.3.0"                 % Test classifier "tests",
+    "uk.gov.hmrc"             %% "bootstrap-play-26"            % "2.1.0"                 % Test classifier "tests",
     "uk.gov.hmrc"             %% "hmrctest"                     % "3.9.0-play-26"         % "test, it",
     "org.scalatest"           %% "scalatest"                    % "3.0.8"                 % "test",
     "com.typesafe.play"       %% "play-test"                    % current                 % "test",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.18
+sbt.version=1.3.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,11 +5,11 @@ resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.5.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.10.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.0.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.8.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
 


### PR DESCRIPTION
Upgraded versions to match expected versions in the Tax Platform Catalogue.

To fix the resulting errors and warnings:

Changed the emueller-bintray resolver to use https
Removed unused logging config from the conf
Updated deprecated conf attributes