### PR TITLE
Reduce test logging

### DIFF
--- a/conf/logback-test.xml
+++ b/conf/logback-test.xml
@@ -50,7 +50,7 @@
 
     <logger name="uk.gov" level="OFF"/>
 
-    <logger name="application" level="DEBUG"/>
+    <logger name="application" level="ERROR"/>
 
     <logger name="connector" level="ERROR">
         <appender-ref ref="STDOUT"/>

--- a/test/utils/SchemaValidation.scala
+++ b/test/utils/SchemaValidation.scala
@@ -41,7 +41,7 @@ trait SchemaValidation {
     val jsonParser = jsonFactory.createParser(json.toString)
     val jsonNode: JsonNode = jsonMapper.readTree(jsonParser)
     val result: ProcessingReport = loadRequestSchema(schemaName, schemaVersion).validate(jsonNode)
-    if(!result.isSuccess) Logger.error(result.toString)
+    if(!result.isSuccess) Logger.info(result.toString)
     result.isSuccess
   }
 }


### PR DESCRIPTION
Reduced the logging level of the test schema validation to info from error. This is a test helper and we are fabricating these scenarios where json fails schema validation.

Increased the logging level in logback-test so that running the tests doesn't output all logs. The logs were mostly logging http requests and json validation failures.