### PR TITLE
CIR-1001

### DIFF
--- a/app/utils/ReadStringWithTrim.scala
+++ b/app/utils/ReadStringWithTrim.scala
@@ -14,19 +14,17 @@
  * limitations under the License.
  */
 
-package v1.models
+package utils
 
-import play.api.libs.json.Json
-import v1.validation.AgentDetailsValidator
-import utils.ReadStringWithTrim.stringReads
+import play.api.libs.json._
 
-case class AgentDetailsModel(agentActingOnBehalfOfCompany: Boolean,
-                             agentName: Option[String]) extends AgentDetailsValidator {
-  override val agentDetailsModel = this
+object ReadStringWithTrim {
+
+  object Reads extends DefaultReads
+
+  implicit val stringReads: Reads[String] = new Reads[String] {
+    def reads(js: JsValue): JsResult[String] = Reads.StringReads.reads(js).map(_.trim)
+  }
+  
 }
 
-object AgentDetailsModel {
-
-  implicit val format = Json.format[AgentDetailsModel]
-
-}

--- a/app/v1/models/CompanyNameModel.scala
+++ b/app/v1/models/CompanyNameModel.scala
@@ -16,12 +16,12 @@
 
 package v1.models
 
-import play.api.libs.json.{JsPath, JsString, Reads, Writes}
+import play.api.libs.json.{JsPath, Reads, Writes, JsString}
 import v1.validation.CompanyNameValidator
-
+import utils.ReadStringWithTrim.stringReads
 
 case class CompanyNameModel(name: String) extends CompanyNameValidator {
-  override val companyNameModel: CompanyNameModel = this
+  val companyNameModel = this
 }
 
 object CompanyNameModel {
@@ -33,3 +33,4 @@ object CompanyNameModel {
   }
 
 }
+

--- a/app/v1/models/NonConsolidatedInvestmentModel.scala
+++ b/app/v1/models/NonConsolidatedInvestmentModel.scala
@@ -18,12 +18,11 @@ package v1.models
 
 import play.api.libs.json.Json
 import v1.validation.NonConsolidatedInvestmentValidator
-
+import utils.ReadStringWithTrim.stringReads
 
 case class NonConsolidatedInvestmentModel(investmentName: String) extends NonConsolidatedInvestmentValidator {
   override val nonConsolidatedInvestmentModel = this
 }
-
 
 object NonConsolidatedInvestmentModel {
   implicit val format = Json.format[NonConsolidatedInvestmentModel]

--- a/app/v1/models/RevisedReturnDetailsModel.scala
+++ b/app/v1/models/RevisedReturnDetailsModel.scala
@@ -18,7 +18,7 @@ package v1.models
 
 import play.api.libs.json.{JsPath, JsString, Reads, Writes}
 import v1.validation.RevisedReturnDetailsValidator
-
+import utils.ReadStringWithTrim.stringReads
 
 case class RevisedReturnDetailsModel(details: String) extends RevisedReturnDetailsValidator {
   override val revisedReturnDetailsModel: RevisedReturnDetailsModel = this

--- a/app/v1/validation/AgentDetailsValidator.scala
+++ b/app/v1/validation/AgentDetailsValidator.scala
@@ -47,9 +47,9 @@ trait AgentDetailsValidator extends BaseValidation {
 
   private def validateAgentNameCharacters(agentName: String)(implicit topPath: JsPath): ValidationResult[Option[String]] = {
     val regex = "^[ -~¡-ÿĀ-ʯḀ-ỿ‐-―‘-‟₠-₿ÅK]*$".r
-    regex.findFirstIn(agentName) match {
-      case Some(_) => Some(agentName).validNec
-      case None => AgentNameCharactersError(agentName).invalidNec
+    agentName match {
+      case regex(_ *) => Some(agentName).validNec
+      case _ => AgentNameCharactersError(agentName).invalidNec
     }
   }
 

--- a/app/v1/validation/CompanyNameValidator.scala
+++ b/app/v1/validation/CompanyNameValidator.scala
@@ -36,9 +36,9 @@ trait CompanyNameValidator extends BaseValidation {
 
   private def validateCompanyNameCharacters(implicit topPath: JsPath): ValidationResult[String] = {
     val regex = "^[ -~¡-ÿĀ-ʯḀ-ỿ‐-―‘-‟₠-₿ÅK]*$".r
-    regex.findFirstIn(companyNameModel.name) match {
-      case Some(_) => companyNameModel.name.validNec
-      case None => CompanyNameCharactersError(companyNameModel.name).invalidNec
+    companyNameModel.name match {
+      case regex(_ *) => companyNameModel.name.validNec
+      case _ => CompanyNameCharactersError(companyNameModel.name).invalidNec
     }
   }
 

--- a/app/v1/validation/NonConsolidatedInvestmentValidator.scala
+++ b/app/v1/validation/NonConsolidatedInvestmentValidator.scala
@@ -36,9 +36,9 @@ trait NonConsolidatedInvestmentValidator extends BaseValidation {
 
   private def validateCompanyNameCharacters(implicit path: JsPath): ValidationResult[String] = {
     val regex = "^[ -~¢-¥©®±×÷‐₠-₿−-∝≈≠≣-≥]*$".r
-    regex.findFirstIn(nonConsolidatedInvestmentModel.investmentName) match {
-      case Some(_) => nonConsolidatedInvestmentModel.investmentName.validNec
-      case None => NonConsolidatedInvestmentNameCharacterError(nonConsolidatedInvestmentModel.investmentName).invalidNec
+    nonConsolidatedInvestmentModel.investmentName match {
+      case regex(_ *) => nonConsolidatedInvestmentModel.investmentName.validNec
+      case _ => NonConsolidatedInvestmentNameCharacterError(nonConsolidatedInvestmentModel.investmentName).invalidNec
     }
   }
 

--- a/app/v1/validation/RevisedReturnDetailsValidator.scala
+++ b/app/v1/validation/RevisedReturnDetailsValidator.scala
@@ -30,7 +30,10 @@ trait RevisedReturnDetailsValidator extends BaseValidation {
 
   private def revisedReturnDetailsHasValidCharacters: Boolean = {
     val regex = "^[ -~¢-¥©®±×÷‐₠-₿−-∝≈≠≣-≥]*$".r
-    regex.findFirstIn(revisedReturnDetailsModel.details).isDefined
+    revisedReturnDetailsModel.details match {
+      case regex(_ *) => true
+      case _ => false
+    }
   }
 
   def validate(implicit path: JsPath): ValidationResult[RevisedReturnDetailsModel] = {

--- a/test/assets/AgentDetailsConstants.scala
+++ b/test/assets/AgentDetailsConstants.scala
@@ -41,4 +41,10 @@ object AgentDetailsConstants {
     agentActingOnBehalfOfCompany = false,
     agentName = None
   )
+
+  val agentDetailsJsonWhitespaceName = Json.obj(
+    "agentActingOnBehalfOfCompany" -> true,
+    "agentName" -> " some agent "
+  )
+
 }

--- a/test/assets/NonConsolidatedInvestmentConstants.scala
+++ b/test/assets/NonConsolidatedInvestmentConstants.scala
@@ -30,4 +30,8 @@ object NonConsolidatedInvestmentConstants {
   val nonConsolidatedJson = Json.obj(
     "investmentName" -> investmentName
   )
+
+  val nonConsolidatedJsonWhitespace = Json.obj(
+    "investmentName" -> " some Investment "
+  )
 }

--- a/test/utils/ReadStringWithTrimSpec.scala
+++ b/test/utils/ReadStringWithTrimSpec.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import org.scalatest.{Matchers, WordSpec}
+import play.api.libs.json.{JsString, Json, Format}
+
+class ReadStringWithTrimSpec extends WordSpec with Matchers {
+
+  case class TestModelOurReads(someString: String, someInt: Int)
+  object TestModelOurReads {
+    import utils.ReadStringWithTrim.stringReads
+    implicit val format: Format[TestModelOurReads] = Format[TestModelOurReads](Json.reads[TestModelOurReads], Json.writes[TestModelOurReads])
+  }
+
+  case class TestModelDefaultReads(someString: String, someInt: Int)
+  object TestModelDefaultReads {
+    implicit val format: Format[TestModelDefaultReads] = Format[TestModelDefaultReads](Json.reads[TestModelDefaultReads], Json.writes[TestModelDefaultReads])
+  }
+  
+  "stringReads" should {
+    "trim a top level string where it is imported" in {
+      val testJson = JsString(" Some string ")
+      testJson.as[String] shouldBe " Some string "
+
+      import utils.ReadStringWithTrim.stringReads
+      testJson.as[String] shouldBe "Some string"
+    }
+
+    "trim a nested string where it is imported" in {
+      val testJson = Json.obj(
+        "someString" -> " Some string ",
+        "someInt" -> 123
+      )
+      testJson.as[TestModelDefaultReads] shouldBe TestModelDefaultReads(" Some string ", 123)
+      testJson.as[TestModelOurReads] shouldBe TestModelOurReads("Some string", 123)
+    }
+
+  }
+
+}

--- a/test/v1/models/AgentDetailsModelSpec.scala
+++ b/test/v1/models/AgentDetailsModelSpec.scala
@@ -61,6 +61,18 @@ class AgentDetailsModelSpec extends WordSpec with Matchers {
 
         actualValue shouldBe expectedValue
       }
+
     }
+
+    "trim the name where it is populated" when {
+
+      "max values given" in {
+
+        val expectedValue = agentDetailsModelMax
+        val actualValue = agentDetailsJsonWhitespaceName.as[AgentDetailsModel]
+
+        actualValue shouldBe expectedValue
+      }   
+    } 
   }
 }

--- a/test/v1/models/NonConsolidatedInvestmentModelSpec.scala
+++ b/test/v1/models/NonConsolidatedInvestmentModelSpec.scala
@@ -16,17 +16,17 @@
 
 package v1.models
 
-import play.api.libs.json.Json
-import v1.validation.AgentDetailsValidator
-import utils.ReadStringWithTrim.stringReads
+import assets.NonConsolidatedInvestmentConstants._
+import org.scalatest.{Matchers, WordSpec}
 
-case class AgentDetailsModel(agentActingOnBehalfOfCompany: Boolean,
-                             agentName: Option[String]) extends AgentDetailsValidator {
-  override val agentDetailsModel = this
-}
+class NonConsolidatedInvestmentModelSpec extends WordSpec with Matchers {
+  "NonConsolidatedInvestmentModel" should {
+    "trim the whitespace in the name" in {
 
-object AgentDetailsModel {
+    val expectedValue = nonConsolidatedModel
+    val actualValue = nonConsolidatedJsonWhitespace.as[NonConsolidatedInvestmentModel]
 
-  implicit val format = Json.format[AgentDetailsModel]
-
+    actualValue shouldBe expectedValue
+    }
+  }
 }

--- a/test/v1/models/RevisedReturnDetailsModelSpec.scala
+++ b/test/v1/models/RevisedReturnDetailsModelSpec.scala
@@ -16,17 +16,18 @@
 
 package v1.models
 
-import play.api.libs.json.Json
-import v1.validation.AgentDetailsValidator
-import utils.ReadStringWithTrim.stringReads
+import org.scalatest.{Matchers, WordSpec}
+import play.api.libs.json.JsString
 
-case class AgentDetailsModel(agentActingOnBehalfOfCompany: Boolean,
-                             agentName: Option[String]) extends AgentDetailsValidator {
-  override val agentDetailsModel = this
-}
+class RevisedReturnDetailsModelSpec extends WordSpec with Matchers {
+  "RevisedReturnDetailsModel" should {
+    "trim the whitespace in the name" in {
 
-object AgentDetailsModel {
+    val expectedValue = RevisedReturnDetailsModel("Some details")
+    val json = JsString(" Some details ")
+    val actualValue = json.as[RevisedReturnDetailsModel]
 
-  implicit val format = Json.format[AgentDetailsModel]
-
+    actualValue shouldBe expectedValue
+    }
+  }
 }

--- a/test/v1/validation/AgentDetailsValidatorSpec.scala
+++ b/test/v1/validation/AgentDetailsValidatorSpec.scala
@@ -68,5 +68,11 @@ class AgentDetailsValidatorSpec extends BaseSpec {
       leftSideError(model.validate).errorMessage shouldBe AgentNameCharactersError(invalidName).errorMessage
     }
 
+    "passed true and Some name with an end of line should not succeed" in {
+      val invalidName = "\n"
+      val model = AgentDetailsModel(true, Some(invalidName))
+      leftSideError(model.validate).errorMessage shouldBe AgentNameCharactersError(invalidName).errorMessage
+    }
+
   }
 }

--- a/test/v1/validation/CompanyNameValidatorSpec.scala
+++ b/test/v1/validation/CompanyNameValidatorSpec.scala
@@ -49,6 +49,12 @@ class CompanyNameValidatorSpec extends WordSpec with Matchers {
         val model = CompanyNameModel(invalidName)
         model.validate.toEither.left.get.head.errorMessage shouldBe CompanyNameCharactersError(model.name).errorMessage
       }
+
+      "company name contains an end of line" in {
+        val model = CompanyNameModel("1111\n222222")
+        model.validate.toEither.left.get.head.errorMessage shouldBe CompanyNameCharactersError(model.name).errorMessage
+      }
+
     }
   }
 }

--- a/test/v1/validation/NonConsolidatedInvestmentValidatorSpec.scala
+++ b/test/v1/validation/NonConsolidatedInvestmentValidatorSpec.scala
@@ -49,6 +49,14 @@ class NonConsolidatedInvestmentValidatorSpec extends BaseValidationSpec {
           model.validate.toEither.left.get.head.errorMessage shouldBe NonConsolidatedInvestmentNameCharacterError(investmentName).errorMessage
         }
 
+        "contains an end of line" in {
+          val name = "\n"
+          val model = nonConsolidatedModel.copy(investmentName = name)
+
+          model.validate.toEither.left.get.head.errorMessage shouldBe NonConsolidatedInvestmentNameCharacterError(investmentName).errorMessage
+        }
+
+
         "isElected is true and no investment names are given" in {
           val model = nonConsolidatedModel.copy(investmentName = "")
           model.validate.toEither.left.get.head.errorMessage shouldBe NonConsolidatedInvestmentNameLengthError("").errorMessage

--- a/test/v1/validation/RevisedReturnDetailsValidatorSpec.scala
+++ b/test/v1/validation/RevisedReturnDetailsValidatorSpec.scala
@@ -42,6 +42,11 @@ class RevisedReturnDetailsValidatorSpec extends BaseSpec {
         val returnDetails = "New!£$%^&*()_ComPan\n with spacs Ā to ʯ, Ḁ to ỿ :' ₠ to ₿ Å and K lenth is 160 characters no numbers allowed New!£$%^&*()_ComPany with spaces Ā to ʯ, Ḁ to ỿ"
         leftSideError(RevisedReturnDetailsModel(returnDetails).validate).errorMessage shouldBe RevisedReturnDetailsCharacterError(returnDetails).errorMessage
       }
+
+      "Return type is Revised and the revised return details contain an end of line character" in {
+        val returnDetails = "\n"
+        leftSideError(RevisedReturnDetailsModel(returnDetails).validate).errorMessage shouldBe RevisedReturnDetailsCharacterError(returnDetails).errorMessage
+      }
     }
   }
 


### PR DESCRIPTION
Fixed validation for EOL characters:
Previously we were using multiline regex matching whereas downstream weren't. This meant that if there were multiple lines in the string but every line individually passed the regex, we would pass the validation but downstream would fail because it wasn't a single line which is what the regex expects.

Added implicit trimming of strings when reading from Json. This means that blank strings are validated as empty. To apply it to a class, simply import utils.ReadStringWithTrim.stringReads in the file containing the defined reads or format for that class.