### PR TITLE
CIR-1496 - Change error response where we got a non-201 from EIS

### DIFF
--- a/app/v1/connectors/DesBaseConnector.scala
+++ b/app/v1/connectors/DesBaseConnector.scala
@@ -19,7 +19,7 @@ package v1.connectors
 import config.AppConfig
 import v1.connectors.HttpHelper.SubmissionResponse
 import play.api.Logging
-import play.api.http.Status.CREATED
+import play.api.http.Status.{CREATED, INTERNAL_SERVER_ERROR}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.http.logging.Authorization
 import v1.models.requests.IdentifierRequest
@@ -46,7 +46,7 @@ trait DesBaseConnector {
         )
       case status =>
         logger.warn(s"[$parserName][read]: Unexpected response, status $status returned with body ${response.body}")
-        Left(UnexpectedFailure(response.status,s"Status ${response.status} $unexpectedErrorMessage"))
+        Left(UnexpectedFailure(INTERNAL_SERVER_ERROR,s"Status $INTERNAL_SERVER_ERROR $unexpectedErrorMessage"))
     }
   }
 }

--- a/test/v1/connectors/httpParsers/AbbreviatedReturnHttpParserSpec.scala
+++ b/test/v1/connectors/httpParsers/AbbreviatedReturnHttpParserSpec.scala
@@ -56,13 +56,21 @@ class AbbreviatedReturnHttpParserSpec extends WordSpec with Matchers with GuiceO
 
     "given any other status" should {
 
-      "return a Left(UnexpectedFailure)" in {
+      val expectedResult = Left(UnexpectedFailure(
+        Status.INTERNAL_SERVER_ERROR,
+        s"Status ${Status.INTERNAL_SERVER_ERROR} Error returned when trying to submit abbreviated return"
+      ))
 
-        val expectedResult = Left(UnexpectedFailure(
-          Status.INTERNAL_SERVER_ERROR,
-          s"Status ${Status.INTERNAL_SERVER_ERROR} Error returned when trying to submit abbreviated return"
-        ))
+      "return a Left(UnexpectedFailure) for a 500" in {
+
         val actualResult = AbbreviatedReturnReads.read("", "", HttpResponse(Status.INTERNAL_SERVER_ERROR, Json.obj(), Map.empty[String,Seq[String]]))
+
+        actualResult shouldBe expectedResult
+      }
+
+      "return a Left(UnexpectedFailure) for a 200" in {
+
+        val actualResult = AbbreviatedReturnReads.read("", "", HttpResponse(Status.OK, ackRefResponse, Map.empty[String,Seq[String]]))
 
         actualResult shouldBe expectedResult
       }

--- a/test/v1/connectors/httpParsers/AppointReportingCompanyHttpParserSpec.scala
+++ b/test/v1/connectors/httpParsers/AppointReportingCompanyHttpParserSpec.scala
@@ -55,14 +55,22 @@ class AppointReportingCompanyHttpParserSpec extends WordSpec with Matchers with 
 
 
     "given any other status" should {
+      
+      val expectedResult = Left(UnexpectedFailure(
+        Status.INTERNAL_SERVER_ERROR,
+        s"Status ${Status.INTERNAL_SERVER_ERROR} Error returned when trying to appoint a reporting company"
+      ))
 
-      "return a Left(UnexpectedFailure)" in {
+      "return a Left(UnexpectedFailure) for a 500" in {
 
-        val expectedResult = Left(UnexpectedFailure(
-          Status.INTERNAL_SERVER_ERROR,
-          s"Status ${Status.INTERNAL_SERVER_ERROR} Error returned when trying to appoint a reporting company"
-        ))
         val actualResult = AppointReportingCompanyReads.read("", "", HttpResponse(Status.INTERNAL_SERVER_ERROR, Json.obj(), Map.empty[String,Seq[String]]))
+
+        actualResult shouldBe expectedResult
+      }
+
+      "return a Left(UnexpectedFailure) for a 200" in {
+
+        val actualResult = AppointReportingCompanyReads.read("", "", HttpResponse(Status.OK, ackRefResponse, Map.empty[String,Seq[String]]))
 
         actualResult shouldBe expectedResult
       }

--- a/test/v1/connectors/httpParsers/FullReturnHttpParserSpec.scala
+++ b/test/v1/connectors/httpParsers/FullReturnHttpParserSpec.scala
@@ -54,13 +54,21 @@ class FullReturnHttpParserSpec extends WordSpec with Matchers with GuiceOneAppPe
     }
     "given any other status" should {
 
-      "return a Left(UnexpectedFailure)" in {
+      val expectedResult = Left(UnexpectedFailure(
+        Status.INTERNAL_SERVER_ERROR,
+        s"Status ${Status.INTERNAL_SERVER_ERROR} Error returned when trying to submit a full return"
+      ))
 
-        val expectedResult = Left(UnexpectedFailure(
-          Status.INTERNAL_SERVER_ERROR,
-          s"Status ${Status.INTERNAL_SERVER_ERROR} Error returned when trying to submit a full return"
-        ))
+      "return a Left(UnexpectedFailure) for a 500" in {
+
         val actualResult = FullReturnReads.read("", "", HttpResponse(Status.INTERNAL_SERVER_ERROR, Json.obj(), Map.empty[String,Seq[String]]))
+
+        actualResult shouldBe expectedResult
+      }
+
+      "return a Left(UnexpectedFailure) for a 200" in {
+
+        val actualResult = FullReturnReads.read("", "", HttpResponse(Status.OK, ackRefResponse, Map.empty[String,Seq[String]]))
 
         actualResult shouldBe expectedResult
       }

--- a/test/v1/connectors/httpParsers/RevokeReportingCompanyHttpParserSpec.scala
+++ b/test/v1/connectors/httpParsers/RevokeReportingCompanyHttpParserSpec.scala
@@ -56,13 +56,21 @@ class RevokeReportingCompanyHttpParserSpec extends WordSpec with Matchers with G
 
     "given any other status" should {
 
-      "return a Left(UnexpectedFailure)" in {
+      val expectedResult = Left(UnexpectedFailure(
+        Status.INTERNAL_SERVER_ERROR,
+        s"Status ${Status.INTERNAL_SERVER_ERROR} Error returned when trying to revoke a reporting company"
+      ))
 
-        val expectedResult = Left(UnexpectedFailure(
-          Status.INTERNAL_SERVER_ERROR,
-          s"Status ${Status.INTERNAL_SERVER_ERROR} Error returned when trying to revoke a reporting company"
-        ))
+      "return a Left(UnexpectedFailure) for a 500" in {
+
         val actualResult = RevokeReportingCompanyReads.read("", "", HttpResponse(Status.INTERNAL_SERVER_ERROR, Json.obj(), Map.empty[String,Seq[String]]))
+
+        actualResult shouldBe expectedResult
+      }
+
+      "return a Left(UnexpectedFailure) for a 200" in {
+
+        val actualResult = RevokeReportingCompanyReads.read("", "", HttpResponse(Status.OK, ackRefResponse, Map.empty[String,Seq[String]]))
 
         actualResult shouldBe expectedResult
       }


### PR DESCRIPTION
Where EIS return something that is not 201 (including if they return a 200, a 400, a 404, etc) then we want to return a 500 because a creation was not successful.