### PR TITLE
CIR-1016 - Increase the max body size to 10MB

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -34,9 +34,12 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuditModule"
 # A metric filter must be provided
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule"
 
-# Provides an implementation and configures all filters required by a Platform frontend microservice.
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.MicroserviceModule"
-play.http.filters = "uk.gov.hmrc.play.bootstrap.filters.MicroserviceFilters"
+# Provides an implementation and configures all filters required by a Platform backend microservice.
+play.modules.enabled += "uk.gov.hmrc.play.bootstrap.backend.BackendModule"
+play.filters.disabled += "play.filters.csrf.CSRFFilter"
+parsers.anyContent.maxLength = 10MB
+play.http.parser.maxDiskBuffer = 10MB
+play.http.parser.maxMemoryBuffer = 10MB
 
 # Default http client
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"


### PR DESCRIPTION
Brought the filters up to date with the current pattern using the play filters as defaulted in the bootstrap backend.conf.

Added a new max body size to the parser of 10MB.